### PR TITLE
Move Chip Revision Register Check

### DIFF
--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -50,6 +50,14 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
     return false;
   }
 
+  // define the main power control register
+  _pu_ctrl_reg = new Adafruit_I2CRegister(i2c_dev, NAU7802_PU_CTRL);
+
+  if (!reset())
+    return false;
+  if (!enable(true))
+    return false;
+
   /* Check for NAU7802 revision register (0x1F), low nibble should be 0xF. */
   Adafruit_I2CRegister rev_reg =
       Adafruit_I2CRegister(i2c_dev, NAU7802_REVISION_ID);
@@ -58,13 +66,6 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
     return false;
   }
 
-  // define the main power control register
-  _pu_ctrl_reg = new Adafruit_I2CRegister(i2c_dev, NAU7802_PU_CTRL);
-
-  if (!reset())
-    return false;
-  if (!enable(true))
-    return false;
   if (!setLDO(NAU7802_3V0))
     return false;
   if (!setGain(NAU7802_GAIN_128))


### PR DESCRIPTION
For #5. Seems to work. Alternatively, could just remove this register check entirely. The [CircuitPython library](https://github.com/CedarGroveStudios/CircuitPython_NAU7802) does not do the check.

Tested on QT PY M0 running library example:
![Screenshot from 2022-06-20 15-07-02](https://user-images.githubusercontent.com/8755041/174683223-495bb7f6-9cbc-4e94-8d93-65d8475d104e.png)

