### PR TITLE
Channel change

### DIFF
--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -79,7 +79,7 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
     return false;
 
   // PGA stabilizer cap on output; enabled in single channel
-  if(!setPGACap(NAU7802_CAP_ON))
+  if (!setPGACap(NAU7802_CAP_ON))
     return false;
 
   return true;

--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -263,6 +263,21 @@ bool Adafruit_NAU7802::setGain(NAU7802_Gain gain) {
 
 /**************************************************************************/
 /*!
+    @brief  The desired ADC input channel
+    @param  channel Desired channel: NAU7802_CHANNEL1, NAU7802_CHANNEL2
+    @returns False if there was any error during I2C comms
+*/
+/**************************************************************************/
+bool Adafruit_NAU7802::setChannel(NAU7802_Channel channel) {
+  Adafruit_I2CRegister ctrl2_reg = Adafruit_I2CRegister(i2c_dev, NAU7802_CTRL2);
+  Adafruit_I2CRegisterBits channel_select =
+      Adafruit_I2CRegisterBits(&ctrl2_reg, 1, 7); // # bits, bit_shift
+
+  return channel_select.write(channel);
+}
+
+/**************************************************************************/
+/*!
     @brief  The desired ADC gain getter
     @returns The gain: NAU7802_GAIN_1, NAU7802_GAIN_2, NAU7802_GAIN_4,
     NAU7802_GAIN_8, NAU7802_GAIN_16, NAU7802_GAIN_32, NAU7802_GAIN_64,

--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -55,7 +55,7 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
       Adafruit_I2CRegister(i2c_dev, NAU7802_REVISION_ID);
 
   if ((rev_reg.read() & 0xF) != 0xF) {
-    return false;
+    //return false;
   }
 
   // define the main power control register
@@ -83,14 +83,14 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
   Adafruit_I2CRegister pga_reg = Adafruit_I2CRegister(i2c_dev, NAU7802_PGA);
   Adafruit_I2CRegisterBits ldomode =
       Adafruit_I2CRegisterBits(&pga_reg, 1, 6); // # bits, bit_shift
-  if (!ldomode.write(0))
+  if (!ldomode.write(1))
     return false;
 
   // PGA stabilizer cap on output
   Adafruit_I2CRegister pwr_reg = Adafruit_I2CRegister(i2c_dev, NAU7802_POWER);
   Adafruit_I2CRegisterBits capen =
       Adafruit_I2CRegisterBits(&pwr_reg, 1, 7); // # bits, bit_shift
-  if (!capen.write(1))
+  if (!capen.write(0))
     return false;
 
   return true;

--- a/Adafruit_NAU7802.h
+++ b/Adafruit_NAU7802.h
@@ -77,6 +77,12 @@ typedef enum _channel {
   NAU7802_CHANNEL2 = 1,
 } NAU7802_Channel;
 
+/*! Two possible channels */
+typedef enum _cap {
+  NAU7802_CAP_OFF = 0,
+  NAU7802_CAP_ON = 1,
+} NAU7802_Cap;
+
 /**************************************************************************/
 /*!
     @brief  NAU7802 driver.
@@ -85,7 +91,7 @@ typedef enum _channel {
 class Adafruit_NAU7802 {
 public:
   Adafruit_NAU7802();
-  bool begin(TwoWire *theWire = &Wire, bool enableDualchannel = false);
+  bool begin(TwoWire *theWire = &Wire);
   bool reset(void);
   bool enable(bool flag);
   bool available(void);
@@ -94,6 +100,7 @@ public:
   bool setLDO(NAU7802_LDOVoltage voltage);
   NAU7802_LDOVoltage getLDO(void);
   bool setGain(NAU7802_Gain gain);
+  bool setPGACap(NAU7802_Cap cap);
   bool setChannel(NAU7802_Channel channel);
   NAU7802_Gain getGain(void);
   bool setRate(NAU7802_SampleRate gain);

--- a/Adafruit_NAU7802.h
+++ b/Adafruit_NAU7802.h
@@ -85,7 +85,7 @@ typedef enum _channel {
 class Adafruit_NAU7802 {
 public:
   Adafruit_NAU7802();
-  bool begin(TwoWire *theWire = &Wire);
+  bool begin(TwoWire *theWire = &Wire, bool enableDualchannel = false);
   bool reset(void);
   bool enable(bool flag);
   bool available(void);

--- a/Adafruit_NAU7802.h
+++ b/Adafruit_NAU7802.h
@@ -71,6 +71,12 @@ typedef enum _calib_mode {
   NAU7802_CALMOD_GAIN = 3,
 } NAU7802_Calibration;
 
+/*! Two possible channels */
+typedef enum _channel {
+  NAU7802_CHANNEL1 = 0,
+  NAU7802_CHANNEL2 = 1,
+} NAU7802_Channel;
+
 /**************************************************************************/
 /*!
     @brief  NAU7802 driver.
@@ -88,6 +94,7 @@ public:
   bool setLDO(NAU7802_LDOVoltage voltage);
   NAU7802_LDOVoltage getLDO(void);
   bool setGain(NAU7802_Gain gain);
+  bool setChannel(NAU7802_Channel channel);
   NAU7802_Gain getGain(void);
   bool setRate(NAU7802_SampleRate gain);
   NAU7802_SampleRate getRate(void);

--- a/examples/nau7802_2channel/nau7802_2channel.ino
+++ b/examples/nau7802_2channel/nau7802_2channel.ino
@@ -80,13 +80,6 @@ void loop() {
     val1 = nau.read();
     //switch to channel 2
     nau.setChannel(NAU7802_CHANNEL2);
-    nau.calibrate(NAU7802_CALMOD_OFFSET);
-    nau.calibrate(NAU7802_CALMOD_GAIN);
-    //flush 5 readings (not mandatory)
-    /*for (uint8_t i=0; i<5; i++) {
-      while (! nau.available()) delay(1);
-      nau.read();
-    }*/
     channel1 = false;
   } else {
     //wait for available data on channel 2 & read
@@ -95,13 +88,6 @@ void loop() {
   
     //switch back to channel 1
     nau.setChannel(NAU7802_CHANNEL1);
-    nau.calibrate(NAU7802_CALMOD_OFFSET);
-    nau.calibrate(NAU7802_CALMOD_GAIN);
-    //flush 5 readings (not mandatory)
-    /*for (uint8_t i=0; i<5; i++) {
-      while (! nau.available()) delay(1);
-      nau.read();
-    }*/
     channel1 = true;
   }
   Serial.print("Read: "); Serial.print(val1); Serial.print(","); Serial.println(val2);

--- a/examples/nau7802_2channel/nau7802_2channel.ino
+++ b/examples/nau7802_2channel/nau7802_2channel.ino
@@ -1,0 +1,108 @@
+#include <Adafruit_NAU7802.h>
+
+Adafruit_NAU7802 nau;
+
+bool channel1 = true;
+
+void setup() {
+  Serial.begin(115200);
+  delay(1000); //wait for monitor to be opened
+  Serial.println("NAU7802");
+  while (! nau.begin()) {
+    Serial.println("Failed to find NAU7802");
+    delay(1000);
+  }
+  Serial.println("Found NAU7802");
+
+  nau.setLDO(NAU7802_2V7);
+  Serial.print("LDO voltage set to ");
+  switch (nau.getLDO()) {
+    case NAU7802_4V5:  Serial.println("4.5V"); break;
+    case NAU7802_4V2:  Serial.println("4.2V"); break;
+    case NAU7802_3V9:  Serial.println("3.9V"); break;
+    case NAU7802_3V6:  Serial.println("3.6V"); break;
+    case NAU7802_3V3:  Serial.println("3.3V"); break;
+    case NAU7802_3V0:  Serial.println("3.0V"); break;
+    case NAU7802_2V7:  Serial.println("2.7V"); break;
+    case NAU7802_2V4:  Serial.println("2.4V"); break;
+    case NAU7802_EXTERNAL:  Serial.println("External"); break;
+  }
+
+  nau.setGain(NAU7802_GAIN_128);
+  Serial.print("Gain set to ");
+  switch (nau.getGain()) {
+    case NAU7802_GAIN_1:  Serial.println("1x"); break;
+    case NAU7802_GAIN_2:  Serial.println("2x"); break;
+    case NAU7802_GAIN_4:  Serial.println("4x"); break;
+    case NAU7802_GAIN_8:  Serial.println("8x"); break;
+    case NAU7802_GAIN_16:  Serial.println("16x"); break;
+    case NAU7802_GAIN_32:  Serial.println("32x"); break;
+    case NAU7802_GAIN_64:  Serial.println("64x"); break;
+    case NAU7802_GAIN_128:  Serial.println("128x"); break;
+  }
+
+  nau.setRate(NAU7802_RATE_320SPS);
+  Serial.print("Conversion rate set to ");
+  switch (nau.getRate()) {
+    case NAU7802_RATE_10SPS:  Serial.println("10 SPS"); break;
+    case NAU7802_RATE_20SPS:  Serial.println("20 SPS"); break;
+    case NAU7802_RATE_40SPS:  Serial.println("40 SPS"); break;
+    case NAU7802_RATE_80SPS:  Serial.println("80 SPS"); break;
+    case NAU7802_RATE_320SPS:  Serial.println("320 SPS"); break;
+  }
+
+  // Take 10 readings to flush out readings
+  for (uint8_t i=0; i<10; i++) {
+    while (! nau.available()) delay(1);
+    nau.read();
+  }
+
+  while (! nau.calibrate(NAU7802_CALMOD_INTERNAL)) {
+    Serial.println("Failed to calibrate internal offset, retrying!");
+    delay(1000);
+  }
+  Serial.println("Calibrated internal offset");
+
+  while (! nau.calibrate(NAU7802_CALMOD_OFFSET)) {
+    Serial.println("Failed to calibrate system offset, retrying!");
+    delay(1000);
+  }
+  Serial.println("Calibrated system offset");
+}
+
+void loop() {
+  static int32_t val1 = 0;
+  static int32_t val2 = 0;
+  //interleave between channel 1 & 2
+  if(channel1) {
+    //wait for available data on channel 1 & read
+    while (!nau.available()) delayMicroseconds(500);
+    val1 = nau.read();
+    //switch to channel 2
+    nau.setChannel(NAU7802_CHANNEL2);
+    nau.calibrate(NAU7802_CALMOD_OFFSET);
+    nau.calibrate(NAU7802_CALMOD_GAIN);
+    //flush 5 readings (not mandatory)
+    /*for (uint8_t i=0; i<5; i++) {
+      while (! nau.available()) delay(1);
+      nau.read();
+    }*/
+    channel1 = false;
+  } else {
+    //wait for available data on channel 2 & read
+    while (!nau.available()) delayMicroseconds(500);
+    val2 = nau.read();
+  
+    //switch back to channel 1
+    nau.setChannel(NAU7802_CHANNEL1);
+    nau.calibrate(NAU7802_CALMOD_OFFSET);
+    nau.calibrate(NAU7802_CALMOD_GAIN);
+    //flush 5 readings (not mandatory)
+    /*for (uint8_t i=0; i<5; i++) {
+      while (! nau.available()) delay(1);
+      nau.read();
+    }*/
+    channel1 = true;
+  }
+  Serial.print("Read: "); Serial.print(val1); Serial.print(","); Serial.println(val2);
+}

--- a/examples/nau7802_2channel/nau7802_2channel.ino
+++ b/examples/nau7802_2channel/nau7802_2channel.ino
@@ -12,8 +12,9 @@ void setup() {
     Serial.println("Failed to find NAU7802");
     delay(1000);
   }
-  Serial.println("Found NAU7802");
-
+  Serial.println("Found NAU7802, disabling PGA cap for 2 channel operation");
+  nau.setPGACap(NAU7802_CAP_OFF);
+  
   nau.setLDO(NAU7802_2V7);
   Serial.print("LDO voltage set to ");
   switch (nau.getLDO()) {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit NAU7802 Library
-version=1.0.1
+version=1.1.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the NAU7802 ADC converter in the Adafruit shop


### PR DESCRIPTION
Dear Adafruit Team,

for using the NAU7802 in dual channel mode, this PR adds following functions/code:

* Add a `setChannel` method with corresponding typedef enums; switch between channels
* Add a 'setPGACap`method with typedef enums; must be called to disable the capacitor connected to channel 2 pins.
* Add an example for 2 channel mode; this can be achieved with your board by desoldering the cap and attaching the bridge wires there. Excitation connections are done in the screw terminal.
* Bumped version to 1.1.1
* Removed the version check completely (as in #5 / #7 )

THX for your hard work on boards, code and Arduino! 
