### PR TITLE
_pu_ctrl_reg needs to be defined

### DIFF
--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -46,12 +46,13 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
   i2c_dev = new Adafruit_I2CDevice(NAU7802_I2CADDR_DEFAULT, theWire);
 
   /* Try to instantiate the I2C device. */
-  if (!i2c_dev->begin()) {
-    return false;
-  }
+  bool ok = i2c_dev->begin();
 
-  // define the main power control register
+  // define the main power control register 
   _pu_ctrl_reg = new Adafruit_I2CRegister(i2c_dev, NAU7802_PU_CTRL);
+
+  if (!ok)
+    return false;
 
   if (!reset())
     return false;

--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -50,10 +50,11 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
 
   // define the main power control register 
   _pu_ctrl_reg = new Adafruit_I2CRegister(i2c_dev, NAU7802_PU_CTRL);
-
-  if (!ok)
+  
+  if (!ok) {
     return false;
-
+  }
+  
   if (!reset())
     return false;
   if (!enable(true))

--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -48,13 +48,12 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
   /* Try to instantiate the I2C device. */
   bool ok = i2c_dev->begin();
 
-  // define the main power control register 
+  // define the main power control register
   _pu_ctrl_reg = new Adafruit_I2CRegister(i2c_dev, NAU7802_PU_CTRL);
-  
-  if (!ok) {
+
+  if (!ok)
     return false;
-  }
-  
+
   if (!reset())
     return false;
   if (!enable(true))


### PR DESCRIPTION
Dear Adafruit Team,

I noticed that the library blocks if the nau7802 is not connected to the I2C bus. It looks like the _pu_ctrl_reg needs to be defined even if the device is not found on the bus to make the library non-blocking. You can use simple sketch below to test.

best,
    Jan

#include <Adafruit_NAU7802.h>

Adafruit_NAU7802 scale;

void setup(void) {
  bool ok;

  Serial.begin(115200);
  delay(3000);

  ok = scale.begin();
  if (!ok) Serial.println("Error initialising NAU7802");
  scale.setLDO(NAU7802_3V0);
  scale.setGain(NAU7802_GAIN_128);
  scale.setRate(NAU7802_RATE_10SPS);
  scale.calibrate(NAU7802_CALMOD_INTERNAL);
}

void loop(void) {
  long value = scale.read();
  Serial.println(value);
  delay(1000);
} 