### PR TITLE
_pu_ctrl_reg needs to be defined

### DIFF
--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -46,12 +46,13 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
   i2c_dev = new Adafruit_I2CDevice(NAU7802_I2CADDR_DEFAULT, theWire);
 
   /* Try to instantiate the I2C device. */
-  if (!i2c_dev->begin()) {
-    return false;
-  }
+  bool ok = i2c_dev->begin();
 
   // define the main power control register
   _pu_ctrl_reg = new Adafruit_I2CRegister(i2c_dev, NAU7802_PU_CTRL);
+
+  if (!ok)
+    return false;
 
   if (!reset())
     return false;


### PR DESCRIPTION
Dear Adafruit Team,

I noticed that the library blocks if the nau7802 is not connected to the I2C bus. It looks like the _pu_ctrl_reg needs to be defined even if the device is not found on the bus to make the library non-blocking. Please see simple sketch below for testing.

best,
Jan

[nau7802_blocking.zip](https://github.com/adafruit/Adafruit_NAU7802/files/12061794/nau7802_blocking.zip)
