### PR TITLE
Prevent execution of the rest of example program if begin fails

### DIFF
--- a/examples/nau7802_test/nau7802_test.ino
+++ b/examples/nau7802_test/nau7802_test.ino
@@ -7,6 +7,7 @@ void setup() {
   Serial.println("NAU7802");
   if (! nau.begin()) {
     Serial.println("Failed to find NAU7802");
+    while (1) delay(10);  // Don't proceed.
   }
   Serial.println("Found NAU7802");
 


### PR DESCRIPTION
The example sketch checks the return value of the `nau.begin()` call. If it returns `false`, the example sketch prints the helpful "Failed to find NAU7802" message to `Serial`.

Previously it then proceeded with the program execution (including inappropriately printing "Found NAU7802"). The rest of the program can not work correctly if the initialization failed. It might even crash some boards, causing the useful "Failed to find NAU7802" message to not be seen by the user.

The more user friendly behavior implemented here is for the example sketch to go into a perpetual loop if the initialization failed.
