### PR TITLE
Updates for dual channel support

### DIFF
--- a/Adafruit_NAU7802.cpp
+++ b/Adafruit_NAU7802.cpp
@@ -87,13 +87,6 @@ bool Adafruit_NAU7802::begin(TwoWire *theWire) {
   if (!ldomode.write(0))
     return false;
 
-  // PGA stabilizer cap on output
-  Adafruit_I2CRegister pwr_reg = Adafruit_I2CRegister(i2c_dev, NAU7802_POWER);
-  Adafruit_I2CRegisterBits capen =
-      Adafruit_I2CRegisterBits(&pwr_reg, 1, 7); // # bits, bit_shift
-  if (!capen.write(1))
-    return false;
-
   return true;
 }
 
@@ -325,6 +318,23 @@ NAU7802_SampleRate Adafruit_NAU7802::getRate(void) {
       Adafruit_I2CRegisterBits(&ctrl2_reg, 3, 4); // # bits, bit_shift
 
   return (NAU7802_SampleRate)rate_select.read();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Enable or disable optional PGA filters. NOTE - this should only
+    be used for single channel operation.
+    @param enable Use true to enable or false to disable.
+    @returns False if any I2C error occured
+*/
+/**************************************************************************/
+bool Adafruit_NAU7802::setPGACap(bool enable) {
+  Adafruit_I2CRegister pwr_reg = Adafruit_I2CRegister(i2c_dev, NAU7802_POWER);
+  Adafruit_I2CRegisterBits capen =
+      Adafruit_I2CRegisterBits(&pwr_reg, 1, 7); // # bits, bit_shift
+  if (!capen.write(enable ? 1 : 0))
+    return false;
+  return true;
 }
 
 /**************************************************************************/

--- a/Adafruit_NAU7802.h
+++ b/Adafruit_NAU7802.h
@@ -92,6 +92,7 @@ public:
   NAU7802_Gain getGain(void);
   bool setRate(NAU7802_SampleRate gain);
   NAU7802_SampleRate getRate(void);
+  bool setPGACap(bool enable);
   bool calibrate(NAU7802_Calibration mode);
 
 private:

--- a/examples/nau7802_dual_channel/nau7802_dual_channel.ino
+++ b/examples/nau7802_dual_channel/nau7802_dual_channel.ino
@@ -1,0 +1,91 @@
+#include <Adafruit_NAU7802.h>
+
+Adafruit_NAU7802 nau;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("NAU7802");
+  if (! nau.begin()) {
+    Serial.println("Failed to find NAU7802");
+    while (1) delay(10);  // Don't proceed.
+  }
+  Serial.println("Found NAU7802");
+
+  nau.setLDO(NAU7802_3V0);
+  Serial.print("LDO voltage set to ");
+  switch (nau.getLDO()) {
+    case NAU7802_4V5:  Serial.println("4.5V"); break;
+    case NAU7802_4V2:  Serial.println("4.2V"); break;
+    case NAU7802_3V9:  Serial.println("3.9V"); break;
+    case NAU7802_3V6:  Serial.println("3.6V"); break;
+    case NAU7802_3V3:  Serial.println("3.3V"); break;
+    case NAU7802_3V0:  Serial.println("3.0V"); break;
+    case NAU7802_2V7:  Serial.println("2.7V"); break;
+    case NAU7802_2V4:  Serial.println("2.4V"); break;
+    case NAU7802_EXTERNAL:  Serial.println("External"); break;
+  }
+
+  nau.setGain(NAU7802_GAIN_128);
+  Serial.print("Gain set to ");
+  switch (nau.getGain()) {
+    case NAU7802_GAIN_1:  Serial.println("1x"); break;
+    case NAU7802_GAIN_2:  Serial.println("2x"); break;
+    case NAU7802_GAIN_4:  Serial.println("4x"); break;
+    case NAU7802_GAIN_8:  Serial.println("8x"); break;
+    case NAU7802_GAIN_16:  Serial.println("16x"); break;
+    case NAU7802_GAIN_32:  Serial.println("32x"); break;
+    case NAU7802_GAIN_64:  Serial.println("64x"); break;
+    case NAU7802_GAIN_128:  Serial.println("128x"); break;
+  }
+
+  nau.setRate(NAU7802_RATE_320SPS);
+  Serial.print("Conversion rate set to ");
+  switch (nau.getRate()) {
+    case NAU7802_RATE_10SPS:  Serial.println("10 SPS"); break;
+    case NAU7802_RATE_20SPS:  Serial.println("20 SPS"); break;
+    case NAU7802_RATE_40SPS:  Serial.println("40 SPS"); break;
+    case NAU7802_RATE_80SPS:  Serial.println("80 SPS"); break;
+    case NAU7802_RATE_320SPS:  Serial.println("320 SPS"); break;
+  }
+}
+
+void loop() {
+  int32_t chan0, chan1;
+
+  //--------------
+  // CHAN 0
+  //--------------
+  // Switch channel
+  nau.setChannel(0);
+  // Take 10 readings to flush out readings
+  for (uint8_t i=0; i<10; i++) {
+    while (! nau.available()) delay(1);
+    nau.read();
+  }
+  // Take actual reading
+  while (! nau.available()) {
+    delay(1);
+  }
+  chan0 = nau.read();
+
+  //--------------
+  // CHAN 1
+  //--------------
+  // Switch channel
+  nau.setChannel(1);
+  // Take 10 readings to flush out readings
+  for (uint8_t i=0; i<10; i++) {
+    while (! nau.available()) delay(1);
+    nau.read();
+  }
+  // Take actual reading
+  while (! nau.available()) {
+    delay(1);
+  }
+  chan1 = nau.read();
+
+  //--------------
+  // results
+  //--------------
+  Serial.print(chan0); Serial.print(","); Serial.println(chan1);
+}

--- a/examples/nau7802_single_channel/nau7802_single_channel.ino
+++ b/examples/nau7802_single_channel/nau7802_single_channel.ino
@@ -1,0 +1,68 @@
+#include <Adafruit_NAU7802.h>
+
+Adafruit_NAU7802 nau;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("NAU7802");
+  if (! nau.begin()) {
+    Serial.println("Failed to find NAU7802");
+    while (1) delay(10);  // Don't proceed.
+  }
+  Serial.println("Found NAU7802");
+
+  nau.setLDO(NAU7802_3V0);
+  Serial.print("LDO voltage set to ");
+  switch (nau.getLDO()) {
+    case NAU7802_4V5:  Serial.println("4.5V"); break;
+    case NAU7802_4V2:  Serial.println("4.2V"); break;
+    case NAU7802_3V9:  Serial.println("3.9V"); break;
+    case NAU7802_3V6:  Serial.println("3.6V"); break;
+    case NAU7802_3V3:  Serial.println("3.3V"); break;
+    case NAU7802_3V0:  Serial.println("3.0V"); break;
+    case NAU7802_2V7:  Serial.println("2.7V"); break;
+    case NAU7802_2V4:  Serial.println("2.4V"); break;
+    case NAU7802_EXTERNAL:  Serial.println("External"); break;
+  }
+
+  nau.setGain(NAU7802_GAIN_128);
+  Serial.print("Gain set to ");
+  switch (nau.getGain()) {
+    case NAU7802_GAIN_1:  Serial.println("1x"); break;
+    case NAU7802_GAIN_2:  Serial.println("2x"); break;
+    case NAU7802_GAIN_4:  Serial.println("4x"); break;
+    case NAU7802_GAIN_8:  Serial.println("8x"); break;
+    case NAU7802_GAIN_16:  Serial.println("16x"); break;
+    case NAU7802_GAIN_32:  Serial.println("32x"); break;
+    case NAU7802_GAIN_64:  Serial.println("64x"); break;
+    case NAU7802_GAIN_128:  Serial.println("128x"); break;
+  }
+
+  nau.setRate(NAU7802_RATE_10SPS);
+  Serial.print("Conversion rate set to ");
+  switch (nau.getRate()) {
+    case NAU7802_RATE_10SPS:  Serial.println("10 SPS"); break;
+    case NAU7802_RATE_20SPS:  Serial.println("20 SPS"); break;
+    case NAU7802_RATE_40SPS:  Serial.println("40 SPS"); break;
+    case NAU7802_RATE_80SPS:  Serial.println("80 SPS"); break;
+    case NAU7802_RATE_320SPS:  Serial.println("320 SPS"); break;
+  }
+
+  // Take 10 readings to flush out readings
+  for (uint8_t i=0; i<10; i++) {
+    while (! nau.available()) delay(1);
+    nau.read();
+  }
+
+  // SINGLE CHANNEL ONLY!!!
+  // enable use of PGA stabilizer caps (Cfilter) on VIN2
+  nau.setPGACap(true);
+}
+
+void loop() {
+  while (! nau.available()) {
+    delay(1);
+  }
+  int32_t val = nau.read();
+  Serial.print("Read "); Serial.println(val);
+}


### PR DESCRIPTION
This is for #20.

A couple of significant changes
  * Removed enabling of external PGA filters in `::begin()` since this is only applicable to single channel configuration (i.e. the original version of [PID 4538](https://www.adafruit.com/product/4538)). This has been moved to new function `setPGACap()` which can be called from user code, as shown in new `nau7802_single_channel` example.
  * The two new examples do *not* call the calibration functions. The behavior of these functions is confusing in the two channel scenario.

Tested with a rev C two channel version of PID 4538 on a Qt PY M0 and two 10kg strain gauges.

Example output from `nau7802_dual_channel` example:
 
<img width="1012" height="500" alt="Screenshot from 2025-09-16 11-19-21" src="https://github.com/user-attachments/assets/61266d38-1f60-4349-a7ff-14d299619b77" />


